### PR TITLE
Dont limit user to a forced version of certain build tools

### DIFF
--- a/libprotobuf_recipe/meta.yaml
+++ b/libprotobuf_recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # breaks backwards compatibility and new SONAME each minor release
     # https://abi-laboratory.pro/tracker/timeline/protobuf/

--- a/libprotobuf_recipe/meta.yaml
+++ b/libprotobuf_recipe/meta.yaml
@@ -33,11 +33,11 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make
-    - autoconf {{ autoconf }}
-    - automake {{ automake }}
-    - libtool {{ libtool }}
+    - autoconf
+    - automake
+    - libtool
     - pkg-config {{ pkg_config }}
-    - unzip {{ unzip }}
+    - unzip
   host:
     - zlib {{ zlib }}
   run:


### PR DESCRIPTION
User shouldnt be forced to have specific version of some general tools (e.g. make), if we are not truly using version-specific features. We arent requiring this consistently across many feedstocks.