### PR TITLE
Disable libprotobuf

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -1,6 +1,3 @@
 recipes:
-  - name : libprotobuf
-    path : libprotobuf_recipe
-
   - name : protobuf
     path : protobuf_recipe


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

libprotobuf is not python version dependent and is included in `defaults` for x86_64 and ppc64le at version 3.9.2.
So we should be using that one and not rebuilding it.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
