### PR TITLE
Revert "Disable libprotobuf"

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -1,3 +1,6 @@
 recipes:
+  - name : libprotobuf
+    path : libprotobuf_recipe
+
   - name : protobuf
     path : protobuf_recipe


### PR DESCRIPTION
Reverts open-ce/protobuf-feedstock#8

This issue caused version conflicts with Power on Python 3.8.