### PR TITLE
USe gcc pins conditionally for 7.2 compilers only

### DIFF
--- a/libprotobuf_recipe/meta.yaml
+++ b/libprotobuf_recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 5
+  number: 6
   run_exports:
     # breaks backwards compatibility and new SONAME each minor release
     # https://abi-laboratory.pro/tracker/timeline/protobuf/
@@ -33,8 +33,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}               # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}         # [x86_64 and c_compiler_version == "7.2.*"]
     - make
     - autoconf
     - automake
@@ -44,8 +44,8 @@ requirements:
   host:
     - zlib {{ zlib }}
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}               # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}         # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - zlib                        # versioning handled by run_exports
 

--- a/protobuf_recipe/meta.yaml
+++ b/protobuf_recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 4
+  number: 5
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 
 requirements:
@@ -19,8 +19,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}                 # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}           # [x86_64 and c_compiler_version == "7.2.*"]
   host:
     - zlib {{ zlib }}
     - python {{ python }}
@@ -28,8 +28,8 @@ requirements:
     - libprotobuf {{ version }}
     - six {{ six }}
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
+    - libgcc-ng  {{ libgcc }}                 # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}           # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - zlib                       # versioning handled by run_exports 
     - python {{ python }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Adjusted gcc pins to make enabled only for compiler 7.2

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
